### PR TITLE
add document repository

### DIFF
--- a/app/assets/docs/sampledoc.md
+++ b/app/assets/docs/sampledoc.md
@@ -1,0 +1,1 @@
+What's up, Doc?

--- a/app/posts/s1-components/1-1-colors/1-1-0-index.md
+++ b/app/posts/s1-components/1-1-colors/1-1-0-index.md
@@ -4,4 +4,4 @@ date: 2012-08-23
 layout: post.html
 ---
 
-Orange is the new black
+[Orange is the new black](/docs/sampledoc.md)

--- a/metalsmith.js
+++ b/metalsmith.js
@@ -8,6 +8,7 @@ var permalinks = require('metalsmith-permalinks');
 var collections = require('metalsmith-collections');
 var debug = require('metalsmith-debug');
 var dirHierarchy = require('metalsmith-directory-hierarchy');
+var assets = require('metalsmith-assets');
 var kebabCase = require('lodash.kebabcase');
 
 module.exports = function (opts) {
@@ -51,6 +52,10 @@ module.exports = function (opts) {
       }]
     }))
     .use(permalinkOverride())
+    .use(assets({
+      source: './app/assets/docs', // relative to the working directory
+      destination: './docs' // relative to the build directory
+    }))
     .use(layouts({
       engine: 'ejs',
       directory: 'app/layouts'

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "metalsmith-collections": "^0.9.0",
     "metalsmith-debug": "^1.1.0",
     "metalsmith-directory-hierarchy": "^1.0.1",
+    "metalsmith-assets": "^0.1.0",
     "metalsmith-layouts": "^1.8.1",
     "metalsmith-markdown": "^0.2.1",
     "metalsmith-permalinks": "^0.5.0",


### PR DESCRIPTION
@danielfdsilva the goal of this feature is to allow a semi-technical user to maintain a repository of static files (PDFs or Docs) and easily link to these files in a post. Adding this to support the use case of an offline document template library.

Caveats:
- If you don't think this use case is central to doc-seed, feel free to reject.
- I ended up using a metalsmith plugin to accomplish this. There may be a better way to do this.
- Let me know if there is a good place to document. Readme didn't seem appropriate.