### PR TITLE
Serve images with absolute URL. Fix #40

### DIFF
--- a/metalsmith.js
+++ b/metalsmith.js
@@ -34,6 +34,7 @@ module.exports = function (opts) {
         sortBy: 'originalURI'
       }
     }))
+    .use(mdImageAbsolutePath(config.baseurl))
     .use(addPostSectionInfo())
     .use(dirHierarchy({
       name: 'hierarchy',
@@ -122,6 +123,29 @@ function originalFileURI (uriKey) {
     setImmediate(done);
     Object.keys(files).forEach(function (file) {
       files[file][uriKey] = file;
+    });
+  };
+}
+
+/**
+ * Image path fix
+ */
+function mdImageAbsolutePath (baseurl) {
+  return function (files, metalsmith, done) {
+    setImmediate(done);
+    const sections = ['contents', 'innovation'];
+    const regEx = new RegExp('="/assets/graphics/content', 'gm');
+    Object.keys(files).forEach(function (key) {
+      let file = files[key]
+      if (file.layout === 'post.html') {
+        sections.forEach(sec => {
+          if (file[sec]) {
+            let content = file[sec].toString();
+            content = content.replace(regEx, `="${baseurl}/assets/graphics/content`);
+            file[sec] = Buffer.from(content, 'utf-8');
+          }
+        });
+      }
     });
   };
 }


### PR DESCRIPTION
This fixes an issue where images are not correctly loaded when the site is hosted on a URL with a subpath. Basically all our GH Pages hosted documentation sites like devseed.com/sez-docs.

This solution substitutes the relative URL for an absolute one during the build process. It is already being used on a number of our Docs sites. Adding it to `doc-seed` as well will save a lot of time going forward.